### PR TITLE
Fix flaky test testToJSONString

### DIFF
--- a/pac4j-oauth/src/test/java/org/pac4j/oauth/profile/JsonHelperTests.java
+++ b/pac4j-oauth/src/test/java/org/pac4j/oauth/profile/JsonHelperTests.java
@@ -71,6 +71,7 @@ public final class JsonHelperTests implements TestsConstants {
         val object = new FacebookObject();
         object.setId(ID);
         object.setName(NAME);
-        assertEquals("\"{\\\"id\\\":\\\"id\\\",\\\"name\\\":\\\"name\\\"}\"", JsonHelper.toJSONString(JsonHelper.toJSONString(object)));
+        String objectstr = JsonHelper.toJSONString(object);
+        assertTrue(objectstr.equals("{\"id\":\"id\",\"name\":\"name\"}") || objectstr.equals("{\"name\":\"name\",\"id\":\"id\"}"));
     }
 }


### PR DESCRIPTION
### Problem
The `testToJSONString` is detected flaky because the `JsonHelper.toJSONString()` gives a non-deterministic output as JSONObject values are unordered. 

### Solution
After modifying `testToJSONString` to expect 2 different string values, the test passes.

**Reason:**
The JSON object is unordered and generally uses Maps as their internal data structure. And, according to [HashMap documentation](https://docs.oracle.com/javase/8/docs/api/java/util/HashMap.html),
_"This class makes no guarantees as to the order of the map; in particular, it does not guarantee that the order will remain constant over time."_
This causes the `JsonHelper.toJSONString()` to give a non-deterministic output.

### Reproduction of the error
The test fails on 5/10 runs of the [NonDex](https://github.com/TestingResearchIllinois/NonDex) tool

**Command to reproduce the failure:**
```mvn -pl pac4j-oauth edu.illinois:nondex-maven-plugin:2.1.7-SNAPSHOT:nondex -Dtest=org.pac4j.oauth.profile.JsonHelperTests#testToJSONString -DnondexRuns=10```

 **Error Message:**
```[ERROR] Tests run: 1, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 0.410 s <<< FAILURE! -- in org.pac4j.oauth.profile.JsonHelperTests
[ERROR] org.pac4j.oauth.profile.JsonHelperTests.testToJSONString -- Time elapsed: 0.396 s <<< FAILURE!
org.junit.ComparisonFailure: expected:<"{\"[id\":\"id\",\"name\":\"name]\"}"> but was:<"{\"[name\":\"name\",\"id\":\"id]\"}">
```
